### PR TITLE
Fix - Wrongly linked javascript topic link

### DIFF
--- a/mentors-list.md
+++ b/mentors-list.md
@@ -13,7 +13,7 @@ Mentors please enter your details in the following table:
 | avinassh  | Python    | Anytime           | Bangalore | No                   |
 | anirudhvarma12         |  Java         |  Anytime(except fridays)                 | Delhi          | yes                     |
 | sathyabhat| SQL/Python| Anytime           | Bangalore | Yes                   |
-| rhnvrm    | [Javascript](curriculum/experimental-cpp.md)| Sat-Sun           | Delhi     | Yes                   |
+| rhnvrm    | [Javascript](curriculum/experimental-js.md)| Sat-Sun           | Delhi     | Yes                   |
 | the100rabh    | Python/Java/Android | Anytime           | Bangalore     | Yes                   |
 | nemo      | [Software Development](curriculum/experimental-software-development.md) | Weekdays | Bangalore |Yes |
 | frag-o-matic      | [Modern C++](curriculum/experimental-cpp.md) | Tue, Thu, Sat [8-9PM IST] | Bangalore |Yes |


### PR DESCRIPTION
In the file `mentors-list.md`, the javascript topic link was linked to `experimental-cpp.md`. It's corrected to `experimental-js.md`.
